### PR TITLE
fix(wifidirect): request NEARBY_WIFI_DEVICES permission on Android 13+

### DIFF
--- a/client/src/lib/wifidirect.js
+++ b/client/src/lib/wifidirect.js
@@ -15,6 +15,7 @@ export const wifiDirectPeers = van.state([])
 export const wifiDirectConnected = van.state(false)
 export const wifiDirectIsGroupOwner = van.state(false)
 export const wifiDirectGroupOwnerAddress = van.state(null)
+export const wifiDirectError = van.state(null)   // 'permission_denied' | 'unsupported' | null
 
 const isCapacitorAndroid = () =>
   typeof window !== 'undefined' &&
@@ -28,10 +29,24 @@ export const initWifiDirect = async ({ onMessage, onPeerChange }) => {
     _plugin = WifiDirect
     _onMessage = onMessage
     _onPeerChange = onPeerChange
+  } catch {
+    return false
+  }
 
-    const result = await _plugin.startDiscovery()
-    if (!result?.supported) return false
+  let result
+  try {
+    result = await _plugin.startDiscovery()
+  } catch (e) {
+    const msg = String(e?.message || e || '')
+    wifiDirectError.val = msg.toLowerCase().includes('denied') ? 'permission_denied' : 'unsupported'
+    return false
+  }
+  if (!result?.supported) {
+    wifiDirectError.val = 'unsupported'
+    return false
+  }
 
+  try {
     _listeners.push(
       _plugin.addListener('peersUpdated', ({ peers }) => {
         wifiDirectPeers.val = Array.isArray(peers) ? peers : []
@@ -48,13 +63,13 @@ export const initWifiDirect = async ({ onMessage, onPeerChange }) => {
         } catch {}
       }),
     )
-
-    _active = true
-    wifiDirectActive.val = true
-    return true
   } catch {
     return false
   }
+
+  _active = true
+  wifiDirectActive.val = true
+  return true
 }
 
 export const stopWifiDirect = async () => {
@@ -69,6 +84,7 @@ export const stopWifiDirect = async () => {
   wifiDirectPeers.val = []
   wifiDirectIsGroupOwner.val = false
   wifiDirectGroupOwnerAddress.val = null
+  wifiDirectError.val = null
 }
 
 export const connectWifiPeer = (address) =>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -247,5 +247,7 @@
   "settings.wifidirect.role.owner": "group owner (server)",
   "settings.wifidirect.role.peer": "peer (client)",
   "settings.wifidirect.group_owner": "group owner IP",
-  "settings.wifidirect.description": "Connects directly to nearby Android devices over Wi-Fi without internet. Enables offline sharing at events, campsites, and other areas without connectivity."
+  "settings.wifidirect.description": "Connects directly to nearby Android devices over Wi-Fi without internet. Enables offline sharing at events, campsites, and other areas without connectivity.",
+  "settings.wifidirect.permission_denied": "permission denied — allow in system settings",
+  "settings.wifidirect.unsupported": "not supported on this device"
 }

--- a/client/src/pages/settingsPage.js
+++ b/client/src/pages/settingsPage.js
@@ -7,7 +7,7 @@ import { requestNotificationPermission, getNotificationPermission } from '../lib
 import { shortPubkey } from '../lib/nostr.js'
 import { installAvailable, promptInstall, isIOS, isStandalone, isCapacitorNative, ANDROID_APK_URL } from '../lib/pwaInstall.js'
 import { updateAvailable, getAppVersion } from '../lib/updateCheck.js'
-import { wifiDirectActive, wifiDirectPeers, wifiDirectConnected, wifiDirectIsGroupOwner, wifiDirectGroupOwnerAddress } from '../lib/wifidirect.js'
+import { wifiDirectActive, wifiDirectPeers, wifiDirectConnected, wifiDirectIsGroupOwner, wifiDirectGroupOwnerAddress, wifiDirectError } from '../lib/wifidirect.js'
 const { div, button, input, span, select, option, label, p, a } = van.tags
 
 const showSideloadHelp = () => {
@@ -207,7 +207,12 @@ export const SettingsPage = () => {
         () => {
           const active = wifiDirectActive.val
           const connected = wifiDirectConnected.val
-          if (!active) return span({ class: 'settings-text-muted' }, () => t('settings.wifidirect.inactive'))
+          const err = wifiDirectError.val
+          if (!active) {
+            if (err === 'permission_denied') return span({ style: 'font-size:12px;color:var(--pink);font-weight:700' }, () => t('settings.wifidirect.permission_denied'))
+            if (err === 'unsupported') return span({ class: 'settings-text-muted' }, () => t('settings.wifidirect.unsupported'))
+            return span({ class: 'settings-text-muted' }, () => t('settings.wifidirect.inactive'))
+          }
           if (connected) return span({ class: 'settings-text-mint' }, '🟢 ', () => t('settings.wifidirect.connected'))
           return span({ style: 'font-size:12px;color:var(--pink);font-weight:700' }, '🔵 ', () => t('settings.wifidirect.scanning'))
         }

--- a/plugins/saysheep-wifidirect/android/src/main/java/earth/saysheep/wifidirect/WifiDirectPlugin.java
+++ b/plugins/saysheep-wifidirect/android/src/main/java/earth/saysheep/wifidirect/WifiDirectPlugin.java
@@ -27,6 +27,7 @@ import java.util.Collection;
     permissions = {
         @Permission(strings = { Manifest.permission.ACCESS_FINE_LOCATION }, alias = "location"),
         @Permission(strings = { Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.CHANGE_WIFI_STATE }, alias = "wifi"),
+        @Permission(strings = { "android.permission.NEARBY_WIFI_DEVICES" }, alias = "nearby"),
     }
 )
 public class WifiDirectPlugin extends Plugin {
@@ -70,8 +71,9 @@ public class WifiDirectPlugin extends Plugin {
     @PluginMethod
     public void startDiscovery(PluginCall call) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (!hasPermission("wifi")) {
-                requestPermissionForAlias("wifi", call, "wifiPermissionCallback");
+            // Android 13+: NEARBY_WIFI_DEVICES replaces location for peer discovery
+            if (!hasPermission("nearby")) {
+                requestPermissionForAlias("nearby", call, "nearbyPermissionCallback");
                 return;
             }
         } else {
@@ -84,11 +86,11 @@ public class WifiDirectPlugin extends Plugin {
     }
 
     @PermissionCallback
-    private void wifiPermissionCallback(PluginCall call) {
-        if (hasPermission("wifi")) {
+    private void nearbyPermissionCallback(PluginCall call) {
+        if (hasPermission("nearby")) {
             directManager.startDiscovery(call);
         } else {
-            call.reject("WiFi permission denied");
+            call.reject("Nearby WiFi Devices permission denied");
         }
     }
 


### PR DESCRIPTION
## Summary

- On Android 13+, `discoverPeers()` requires the `NEARBY_WIFI_DEVICES` runtime permission. The plugin was checking `ACCESS_WIFI_STATE`/`CHANGE_WIFI_STATE` (install-time permissions, always granted), so it called `discoverPeers()` without ever prompting — causing a silent failure and the UI stuck on "inactive".
- Added `"nearby"` permission alias (`NEARBY_WIFI_DEVICES`) to `WifiDirectPlugin.java`; on API ≥ 33 `startDiscovery()` now requests this alias instead of `"wifi"`.
- Added `wifiDirectError` reactive state (`permission_denied` | `unsupported` | `null`) so settings shows a useful message instead of the generic "inactive" label.

## Test plan

- [ ] Fresh install on Android 13+ device → app prompts "Allow saysheep to find nearby devices?" on first open
- [ ] Grant permission → WiFi Direct status changes to "scanning for peers…"
- [ ] Deny permission → status shows "permission denied — allow in system settings"
- [ ] Android 12 and below → location permission prompt appears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiMhLPFHRH7M6vec3PoCsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiMhLPFHRH7M6vec3PoCsd)_